### PR TITLE
Add more origins to CORS Middleware and add an env var to .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,8 +1,10 @@
 # Environment: local, production
 ENVIRONMENT=local
 
+# Backend
+SECRET_KEY=secret_key_for_jwt
+
 # Local Postgres Database (local)
-# change the user, password, and db name to your local PostgreSQL database's info
 POSTGRES_SERVER=localhost
 POSTGRES_PORT= 5432
 POSTGRES_DB=db_name
@@ -11,16 +13,16 @@ POSTGRES_PASSWORD=db_password
 DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/db_name
 
 # Test Postgres Database (local)
-# Create a test database for testing
 TEST_DATABASE_URL=postgresql+asyncpg://testuser:testpassword@localhost:5432/test_db_name
 
-# AUTH 
-# Run 'openssl rand -hex 32' in your terminal to create a secret key
-SECRET_KEY=secrete_key_for_jwt
+# API keys
+SPOONACULAR_API_KEY=dummykey
 
 # Cloud SQL (production)
-# Use the Cloud SQL instance login
 INSTANCE_CONNECTION_NAME=
 DB_USER=
 DB_PASS=
 DB_NAME=
+
+
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,10 +24,18 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+origins = [
+    "http://127.0.0.1:5173",
+    "http://localhost",
+    "http://localhost:5173",
+    "https://localhost",
+    "https://localhost:5173",
+]
+
 # CORS Middleware edited by Zilin Xu
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["https://grocery-frontend-794191262342.us-central1.run.app"],
+    allow_origins=origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
- Add multiple origins to CORS Middleware to allow the frontend to connect with the backend when ran locally.
- Add env variable SPOONACULAR_API_KEY to .env.example